### PR TITLE
Update fabric.mod.json

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -43,7 +43,8 @@
                 "id": "tr7zw-api-parent",
                 "name": "tr7zw Library Modules",
                 "description": "All of tr7zw's embedded library modules in one place!",
-                "icon": "tr_parent_icon.png"
+                "icon": "tr_parent_icon.png",
+                "badges": [ "library" ]
             },
             "update_checker": false
         }


### PR DESCRIPTION
Make "tr7zw Library Modules" parent mod shown as a library

Fixes https://github.com/TerraformersMC/ModMenu/issues/872.