### PR TITLE
Make defaultHandleGameClickEvent static

### DIFF
--- a/src/main/java/dev/tr7zw/trender/gui/impl/mixin/client/ScreenAccessor.java
+++ b/src/main/java/dev/tr7zw/trender/gui/impl/mixin/client/ScreenAccessor.java
@@ -16,6 +16,8 @@ public interface ScreenAccessor {
 
     //? if >= 1.21.11 {
     @Invoker("defaultHandleGameClickEvent")
-    static void libgui$defaultHandleGameClickEvent(ClickEvent clickEvent, Minecraft minecraft, Screen screen);
+    static void libgui$defaultHandleGameClickEvent(ClickEvent clickEvent, Minecraft minecraft, Screen screen) {
+        throw new AssertionError("Mixin invoker stub");
+    }
     //? }
 }

--- a/src/main/java/dev/tr7zw/trender/gui/impl/mixin/client/ScreenAccessor.java
+++ b/src/main/java/dev/tr7zw/trender/gui/impl/mixin/client/ScreenAccessor.java
@@ -16,6 +16,6 @@ public interface ScreenAccessor {
 
     //? if >= 1.21.11 {
     @Invoker("defaultHandleGameClickEvent")
-    void libgui$defaultHandleGameClickEvent(ClickEvent clickEvent, Minecraft minecraft, Screen screen);
+    static void libgui$defaultHandleGameClickEvent(ClickEvent clickEvent, Minecraft minecraft, Screen screen);
     //? }
 }

--- a/src/main/java/dev/tr7zw/trender/gui/widget/WLabel.java
+++ b/src/main/java/dev/tr7zw/trender/gui/widget/WLabel.java
@@ -70,7 +70,7 @@ public class WLabel extends WWidget {
             Screen screen = Minecraft.getInstance().screen;
             if (screen != null) {
                 //? if >= 1.21.11 {
-                ((ScreenAccessor) (Object) Minecraft.getInstance().screen).libgui$defaultHandleGameClickEvent(
+                ScreenAccessor.libgui$defaultHandleGameClickEvent(
                         hoveredTextStyle.getClickEvent(), Minecraft.getInstance(), Minecraft.getInstance().screen);
                 return InputResult.PROCESSED;
                 //? } else {

--- a/src/main/java/dev/tr7zw/trender/gui/widget/WLabel.java
+++ b/src/main/java/dev/tr7zw/trender/gui/widget/WLabel.java
@@ -71,7 +71,7 @@ public class WLabel extends WWidget {
             if (screen != null) {
                 //? if >= 1.21.11 {
                 ScreenAccessor.libgui$defaultHandleGameClickEvent(
-                        hoveredTextStyle.getClickEvent(), Minecraft.getInstance(), Minecraft.getInstance().screen);
+                        hoveredTextStyle.getClickEvent(), Minecraft.getInstance(), screen);
                 return InputResult.PROCESSED;
                 //? } else {
                 /*

--- a/src/main/java/dev/tr7zw/trender/gui/widget/WText.java
+++ b/src/main/java/dev/tr7zw/trender/gui/widget/WText.java
@@ -134,7 +134,7 @@ public class WText extends WWidget {
         Style hoveredTextStyle = getTextStyleAt(x, y);
         if (hoveredTextStyle != null) {
             //? if >= 1.21.11 {
-            ((ScreenAccessor) (Object) Minecraft.getInstance().screen).libgui$defaultHandleGameClickEvent(
+            ScreenAccessor.libgui$defaultHandleGameClickEvent(
                     hoveredTextStyle.getClickEvent(), Minecraft.getInstance(), Minecraft.getInstance().screen);
             boolean processed = true;
             //? } else {


### PR DESCRIPTION
Method seems to be static in 1.21.11. https://maven.fabricmc.net/docs/yarn-1.21.11+build.4/net/minecraft/client/gui/screen/Screen.html#handleClickEvent(net.minecraft.text.ClickEvent,net.minecraft.client.MinecraftClient,net.minecraft.client.gui.screen.Screen) (This is for Yarn mappings, but Mojang mappings of course do not have a Javadoc)

Note: Please let me know if this somehow a Yarn bug and its not static in Mojang mappings/Forge or something

If a mod depending on TRender has used the accessor method, it would compile fine since you can call static methods from instance as well (it's just discouraged), but this a binary incompatible change as javac, even when calling a static method from instance, still generates a invokestatic bytecode instead of invokevirtual, so other mods depending on TRender might need recompilation even if calling the static method from instance.

Note that i didn't compile or test this because running gradle compose takes like an hour and still doesnt finish as it seems to compile for every single Minecraft version seperately (also downloaded like 20 GB of stuff to my disk), would appreciate if someone else could test instead as I had to abort it to not keep thrashing my disk and CPU/RAM further. It should work fine though most probably.

Fixes #2 (hopefully)